### PR TITLE
chore: Build title should take only subject from commit message

### DIFF
--- a/.sun-ci.yml
+++ b/.sun-ci.yml
@@ -29,7 +29,7 @@ jobs:
     stage: test
     image: alpine
     script:
-      - sleep 2
+      - sleep 2 Build title should take only subject from commit message
       - echo ha
     except:
       branches:


### PR DESCRIPTION
- Build title should take only subject from commit message
- Build title should take only subject from commit message